### PR TITLE
Fix broken "Next" link on "Adding a Platform" page

### DIFF
--- a/source/docs/getting-started/adding-platform.html.md
+++ b/source/docs/getting-started/adding-platform.html.md
@@ -190,6 +190,6 @@ default-centos-73    Vagrant  ChefZero     Inspec    Ssh        <Not Created>  <
 ~~~
 
 <div class="sidebar--footer">
-<a class="button primary-cta" href="/docs/getting-started/dynamic-configuration">Next - Dynamic Configuration</a>
+<a class="button primary-cta" href="/docs/getting-started/adding-feature">Next - Adding a Feature</a>
 <a class="sidebar--footer--back" href="/docs/getting-started/running-test">Back to previous step</a>
 </div>


### PR DESCRIPTION
The "Next - Dynamic Configuration" link returns a 404 as the page does not exist. Following the navigation on the sidebar, the next page should be the "Adding a Feature" page.